### PR TITLE
Use platform output.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,8 @@ dyn-clone = "1.0.11"
 pixels = "0.12.1"
 winit = "0.28.6"
 winit_input_helper = "0.14.1"
-egui = "0.22.0"
-eframe = "0.22.0"
+eframe = { version = "0.22", default-features = false, features = ["default_fonts", "wgpu"] }
 rayon = "1.7.0"
-arboard = "3.2.0"
 rfd = "0.11.4"
 png = "0.17.8"
 

--- a/examples/editor.rs
+++ b/examples/editor.rs
@@ -608,8 +608,7 @@ impl eframe::App for EditorApp {
                     }
                 }
                 if ui.button("Copy Code").clicked() {
-                    let mut clipboard = arboard::Clipboard::new().unwrap();
-                    clipboard.set_text(code.clone()).unwrap();
+                    ui.output_mut(|output| output.copied_text = code.clone());
                 }
                 if ui.button("Export PNG").clicked() {
                     self.is_exporting = !self.is_exporting;


### PR DESCRIPTION
These are just suggestions, feel free to close.

You can use [platform output](https://docs.rs/egui/0.22.0/egui/output/struct.PlatformOutput.html) to put things on the clipboard in a more platform-independent way. (Maybe someday you'll do a wasm version?)

Also, I figure you might want to use the wgpu version of eframe since pixels uses it (although they are different versions right now). egui is reexported via eframe so it's not needed as a dep.
